### PR TITLE
Dont use Timber structs when logging events

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.6.6
-erlang 20.3
+elixir 1.8.0
+erlang 21.2

--- a/lib/timber_phoenix.ex
+++ b/lib/timber_phoenix.ex
@@ -330,7 +330,7 @@ defmodule Timber.Phoenix do
       }
     }
 
-    message = ["Received ", event, " on \"", topic, "\" to ", channel]
+    message = ["Received ", event_name, " on \"", topic, "\" to ", channel]
 
     Logger.log(log_level, message, event: event)
   end

--- a/lib/timber_phoenix.ex
+++ b/lib/timber_phoenix.ex
@@ -353,7 +353,7 @@ defmodule Timber.Phoenix do
     controller_actions_blacklist = get_parsed_blacklist()
 
     controller = Phoenix.Controller.controller_module(conn)
-    action = Phoenix.Controller.action(conn)
+    action = Phoenix.Controller.action_name(conn)
 
     if !controller_action_blacklisted?({controller, action}, controller_actions_blacklist) do
       "Elixir." <> controller_name = to_string(controller)

--- a/test/timber_phoenix_test.exs
+++ b/test/timber_phoenix_test.exs
@@ -289,7 +289,7 @@ defmodule Timber.PhoenixTest do
       log =
         capture_log(fn ->
           socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
-          params = 3.14
+          params = %{"key" => "val"}
 
           metadata = %{
             socket: socket,


### PR DESCRIPTION
Timber 2.0 no longer requires a strict schema, this allows events to be logged freely without the concern that events will be rejected if they do not
pass validation. As a result, Timber integration no longer need to use defined event structs, they can simply log the event just as any Timber client
would log a custom event. This gives integrations the freedome to name and define events in any structure they please.

Concrete changes:

* Stopped using `Timber.Events.*` in favor of simple maps
* Updated event names to use the verb past-tense, which follows the recommended naming scheme from Timber
* Moved all `metadata.*` attribute to the root of the event payload.